### PR TITLE
rdkit2d nan values are now correctly filtered

### DIFF
--- a/chebai_graph/preprocessing/properties.py
+++ b/chebai_graph/preprocessing/properties.py
@@ -155,5 +155,5 @@ class RDKit2DNormalized(MolecularProperty):
         features_normalized = generator_normalized.processMol(
             mol, Chem.MolToSmiles(mol)
         )
-        np.nan_to_num(features_normalized)
+        np.nan_to_num(features_normalized, copy=False)
         return [features_normalized[1:]]


### PR DESCRIPTION
RDKit2DNormalized adds a vector of 200 properties from RDKit to the molecule representation. However, sometimes RDKit fails and returns a nan value. These destroy training if kept in the dataset. It seems that a filter had already been added previously, but was not working. Now it should work.

@aditya0by0 It seems to me that you were facing the same issue (e.g. in [this run](https://wandb.ai/chebai/chebai/runs/ejg3ksex)). Please check if this solves the issue of nan values for you as well.