### PR TITLE
use load_processed_data_from_file

### DIFF
--- a/chebai_graph/preprocessing/datasets/chebi.py
+++ b/chebai_graph/preprocessing/datasets/chebi.py
@@ -170,9 +170,8 @@ class GraphPropertiesMixIn(XYBaseDataModule):
             molecule_attr=molecule_attr,
         )
 
-    def load_processed_data(self, kind: str = None, filename: str = None):
-        """Combine base data set with property values for atoms and bonds."""
-        base_data = super().load_processed_data(kind, filename)
+    def load_processed_data_from_file(self, filename):
+        base_data = super().load_processed_data_from_file(filename)
         base_df = pd.DataFrame(base_data)
         for property in self.properties:
             property_data = torch.load(


### PR DESCRIPTION
This is the companion to [a chebai PR](github.com/ChEB-AI/python-chebai/pull/92). Instead of using `load_processed_data` for everything (and inadvertently calling it twice), we can now load the file first and then split into train/val/test. 

See also [this issue](https://github.com/ChEB-AI/python-chebai/pull/92)