### PR TITLE
`GraphPropertyReader` should inherit from Data reader

### DIFF
--- a/chebai_graph/preprocessing/reader.py
+++ b/chebai_graph/preprocessing/reader.py
@@ -16,7 +16,7 @@ from torch_geometric.data import Data as GeomData
 from lightning_utilities.core.rank_zero import rank_zero_warn, rank_zero_info
 
 
-class GraphPropertyReader(dr.ChemDataReader):
+class GraphPropertyReader(dr.DataReader):
     COLLATOR = GraphCollator
 
     def __init__(


### PR DESCRIPTION

### Refactor `GraphPropertyReader` to Inherit from `DataReader`

* `GraphPropertyReader` does not utilize any methods from `ChemDataReader`, making that inheritance unnecessary.
* Inheriting from `ChemDataReader` results in the unintended creation of a `reader_name/tokens.txt` file. This has previously led to empty token files being committed to the `chebai` repository.
  → Example: [Redundant File](https://github.com/ChEB-AI/python-chebai/tree/dev/chebai/preprocessing/bin/graph_properties)
  **This file should be removed from the repository.**
* Token management is already handled by the encoder in the graph repository, so the token handling logic in `ChemDataReader` is redundant for this use case.

