### PR TITLE
fix numpy conversion error

### DIFF
--- a/chebai_graph/preprocessing/properties.py
+++ b/chebai_graph/preprocessing/properties.py
@@ -155,5 +155,5 @@ class RDKit2DNormalized(MolecularProperty):
         features_normalized = generator_normalized.processMol(
             mol, Chem.MolToSmiles(mol)
         )
-        np.nan_to_num(features_normalized, copy=False)
+        features_normalized = np.nan_to_num(features_normalized)
         return [features_normalized[1:]]


### PR DESCRIPTION
When setting `copy` to false, the `np.nan_to_num` function failed for me (with numpy 2.3). Removing `copy=False` should fix the issue.