### PR TITLE
 add descriptatorus to mandatory dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ authors = [
 ]
 dependencies = [
     "chebai",
+    "descriptastorus",
     # below packages need to manually installed as mentioned in readme
     # torch-geometric
     # torch_scatter
@@ -15,7 +16,6 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "tox",
-    "descriptastorus",
 ]
 
 linters = [


### PR DESCRIPTION
In PR #24, i missed a dependency. `descriptastorus` is in fact needed for inference and therefore has to be put under dependencies