### PR TITLE
Add eval mode to property encoder

### DIFF
--- a/chebai_graph/models/base.py
+++ b/chebai_graph/models/base.py
@@ -184,6 +184,7 @@ class GraphNetWrapper(GraphBaseNet, ABC):
             torch.Tensor: Predicted output.
         """
         graph_data = batch["features"][0]
+        graph_data.to(self.device)
         assert isinstance(graph_data, GraphData)
         a = self.gnn(batch)
         a = scatter_add(a, graph_data.batch, dim=0)

--- a/chebai_graph/preprocessing/datasets/__init__.py
+++ b/chebai_graph/preprocessing/datasets/__init__.py
@@ -12,7 +12,7 @@ from .chebi import (
     ChEBI50_WFGE_WGN_GraphProp,
     ChEBI50GraphData,
     ChEBI50GraphProperties,
-    ChEBI100GraphProperties
+    ChEBI100GraphProperties,
 )
 from .pubchem import PubChemGraphProperties
 

--- a/chebai_graph/preprocessing/datasets/__init__.py
+++ b/chebai_graph/preprocessing/datasets/__init__.py
@@ -12,12 +12,14 @@ from .chebi import (
     ChEBI50_WFGE_WGN_GraphProp,
     ChEBI50GraphData,
     ChEBI50GraphProperties,
+    ChEBI100GraphProperties
 )
 from .pubchem import PubChemGraphProperties
 
 __all__ = [
     "ChEBI50GraphFGAugmentorReader",
     "ChEBI50GraphProperties",
+    "ChEBI100GraphProperties",
     "ChEBI50GraphData",
     "PubChemGraphProperties",
     "ChEBI50_Atom_WGNOnly_GraphProp",

--- a/chebai_graph/preprocessing/datasets/chebi.py
+++ b/chebai_graph/preprocessing/datasets/chebi.py
@@ -2,6 +2,7 @@ import os
 from abc import ABC
 from collections.abc import Callable
 from pprint import pformat
+from typing import Optional
 
 import pandas as pd
 import torch
@@ -281,7 +282,7 @@ class GraphPropertiesMixIn(DataPropertiesSetter, ABC):
             molecule_attr=molecule_attr,
         )
 
-    def load_processed_data_from_file(self, filename: str) -> list[dict]:
+    def load_processed_data(self, kind: Optional[str] = None, filename: Optional[str] = None) -> list[dict]:
         """
         Load dataset and merge cached properties into base features.
 
@@ -291,7 +292,7 @@ class GraphPropertiesMixIn(DataPropertiesSetter, ABC):
         Returns:
             List of data entries, each a dictionary.
         """
-        base_data = super().load_processed_data_from_file(filename)
+        base_data = super().load_processed_data(kind, filename)
         base_df = pd.DataFrame(base_data)
 
         for property in self.properties:
@@ -379,7 +380,7 @@ class GraphPropAsPerNodeType(DataPropertiesSetter, ABC):
             f"Data module uses these properties (ordered): {', '.join([str(p) for p in self.properties])}",
         )
 
-    def load_processed_data_from_file(self, filename: str) -> list[dict]:
+    def load_processed_data(self, kind: Optional[str] = None, filename: Optional[str] = None) -> list[dict]:
         """
         Load dataset and merge cached properties into base features.
 
@@ -389,9 +390,8 @@ class GraphPropAsPerNodeType(DataPropertiesSetter, ABC):
         Returns:
             List of data entries, each a dictionary.
         """
-        base_data = super().load_processed_data_from_file(filename)
+        base_data = super().load_processed_data(kind, filename)
         base_df = pd.DataFrame(base_data)
-
         props_categories = {
             "AllNodeTypeProperties": [],
             "FGNodeTypeProperties": [],
@@ -442,6 +442,7 @@ class GraphPropAsPerNodeType(DataPropertiesSetter, ABC):
         )
 
         for property in self.properties:
+            rank_zero_info(f"Loading property {property.name}...")
             property_data = torch.load(
                 self.get_property_path(property), weights_only=False
             )

--- a/chebai_graph/preprocessing/datasets/chebi.py
+++ b/chebai_graph/preprocessing/datasets/chebi.py
@@ -282,7 +282,9 @@ class GraphPropertiesMixIn(DataPropertiesSetter, ABC):
             molecule_attr=molecule_attr,
         )
 
-    def load_processed_data(self, kind: Optional[str] = None, filename: Optional[str] = None) -> list[dict]:
+    def load_processed_data(
+        self, kind: Optional[str] = None, filename: Optional[str] = None
+    ) -> list[dict]:
         """
         Load dataset and merge cached properties into base features.
 
@@ -380,7 +382,9 @@ class GraphPropAsPerNodeType(DataPropertiesSetter, ABC):
             f"Data module uses these properties (ordered): {', '.join([str(p) for p in self.properties])}",
         )
 
-    def load_processed_data(self, kind: Optional[str] = None, filename: Optional[str] = None) -> list[dict]:
+    def load_processed_data(
+        self, kind: Optional[str] = None, filename: Optional[str] = None
+    ) -> list[dict]:
         """
         Load dataset and merge cached properties into base features.
 

--- a/chebai_graph/preprocessing/property_encoder.py
+++ b/chebai_graph/preprocessing/property_encoder.py
@@ -16,9 +16,10 @@ class PropertyEncoder(abc.ABC):
         **kwargs: Additional keyword arguments.
     """
 
-    def __init__(self, property, **kwargs) -> None:
+    def __init__(self, property, eval=False, **kwargs) -> None:
         self.property = property
         self._encoding_length: int = 1
+        self.eval = eval # if True, do not update cache (for index encoder)
 
     @property
     def name(self) -> str:
@@ -149,7 +150,11 @@ class IndexEncoder(PropertyEncoder):
         if token is None:
             self._count_for_unk_token += 1
             return torch.tensor([self._unk_token_idx])
-
+        
+        if self.eval and str(token) not in self.cache:
+            self._count_for_unk_token += 1
+            return torch.tensor([self._unk_token_idx])
+        
         if str(token) not in self.cache:
             self.cache[str(token)] = len(self.cache)
         return torch.tensor([self.cache[str(token)] + self.offset])
@@ -213,6 +218,15 @@ class OneHotEncoder(IndexEncoder):
         Returns:
             One-hot encoded tensor of shape (1, encoding_length).
         """
+        if self.eval:
+            if token is None or str(token) not in self.cache:
+                self._count_for_unk_token += 1
+                return torch.zeros(self.get_encoding_length(), dtype=torch.int64)
+            index = self.cache[str(token)] + self.offset
+            return torch.nn.functional.one_hot(
+                torch.tensor(index), num_classes=self.get_encoding_length()
+            )
+
         if token not in self.tokens_dict:
             self._count_for_unk_token += 1
             return torch.zeros(1, self.get_encoding_length(), dtype=torch.int64)

--- a/chebai_graph/preprocessing/property_encoder.py
+++ b/chebai_graph/preprocessing/property_encoder.py
@@ -19,7 +19,7 @@ class PropertyEncoder(abc.ABC):
     def __init__(self, property, eval=False, **kwargs) -> None:
         self.property = property
         self._encoding_length: int = 1
-        self.eval = eval # if True, do not update cache (for index encoder)
+        self.eval = eval  # if True, do not update cache (for index encoder)
 
     @property
     def name(self) -> str:
@@ -150,11 +150,11 @@ class IndexEncoder(PropertyEncoder):
         if token is None:
             self._count_for_unk_token += 1
             return torch.tensor([self._unk_token_idx])
-        
+
         if self.eval and str(token) not in self.cache:
             self._count_for_unk_token += 1
             return torch.tensor([self._unk_token_idx])
-        
+
         if str(token) not in self.cache:
             self.cache[str(token)] = len(self.cache)
         return torch.tensor([self.cache[str(token)] + self.offset])


### PR DESCRIPTION
When running GNNs in chebifier, I got this error: 

```
AttributeError: 'OneHotEncoder' object has no attribute 'tokens_dict'
```
This happens because the tokens dict only gets created when initialising from a dataset. If initialising from a tokens.txt file, the tokens are stored in the cache. So in eval mode, tokens should be retrieved from the cache.

This PR also makes some other slight adjustments (add device casting for model input, expose ChEBI100 dataset, `load_processed_data` (not just from file, but also by kind)).


Full error:
```
Error on request:
Traceback (most recent call last):
  File "C:\Users\sifluegel\Desktop\Chebifier\backend\.venv\Lib\site-packages\werkzeug\serving.py", line 370, in run_wsgi
    execute(self.server.app)
  File "C:\Users\sifluegel\Desktop\Chebifier\backend\.venv\Lib\site-packages\werkzeug\serving.py", line 331, in execute
    application_iter = app(environ, start_response)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\sifluegel\Desktop\Chebifier\backend\.venv\Lib\site-packages\flask\app.py", line 1536, in __call__
    return self.wsgi_app(environ, start_response)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\sifluegel\Desktop\Chebifier\backend\.venv\Lib\site-packages\flask\app.py", line 1514, in wsgi_app
    response = self.handle_exception(e)
               ^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\sifluegel\Desktop\Chebifier\backend\.venv\Lib\site-packages\flask_restful\__init__.py", line 298, in error_router
    return original_handler(e)
           ^^^^^^^^^^^^^^^^^^^
  File "C:\Users\sifluegel\Desktop\Chebifier\backend\.venv\Lib\site-packages\flask_cors\extension.py", line 194, in wrapped_function
    return cors_after_request(app.make_response(f(*args, **kwargs)))
                                                ^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\sifluegel\Desktop\Chebifier\backend\.venv\Lib\site-packages\flask_restful\__init__.py", line 295, in error_router
    return self.handle_error(e)
           ^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\sifluegel\Desktop\Chebifier\backend\.venv\Lib\site-packages\flask_restful\__init__.py", line 310, in handle_error
    _handle_flask_propagate_exceptions_config(current_app, e)
  File "C:\Users\sifluegel\Desktop\Chebifier\backend\.venv\Lib\site-packages\flask\app.py", line 1511, in wsgi_app
    response = self.full_dispatch_request()
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\sifluegel\Desktop\Chebifier\backend\.venv\Lib\site-packages\flask\app.py", line 919, in full_dispatch_request
    rv = self.handle_user_exception(e)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\sifluegel\Desktop\Chebifier\backend\.venv\Lib\site-packages\flask_restful\__init__.py", line 298, in error_router
    return original_handler(e)
           ^^^^^^^^^^^^^^^^^^^
  File "C:\Users\sifluegel\Desktop\Chebifier\backend\.venv\Lib\site-packages\flask_cors\extension.py", line 194, in wrapped_function
    return cors_after_request(app.make_response(f(*args, **kwargs)))
                                                ^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\sifluegel\Desktop\Chebifier\backend\.venv\Lib\site-packages\flask_restful\__init__.py", line 295, in error_router
    return self.handle_error(e)
           ^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\sifluegel\Desktop\Chebifier\backend\.venv\Lib\site-packages\flask_restful\__init__.py", line 310, in handle_error
    _handle_flask_propagate_exceptions_config(current_app, e)
  File "C:\Users\sifluegel\Desktop\Chebifier\backend\.venv\Lib\site-packages\flask\app.py", line 917, in full_dispatch_request
    rv = self.dispatch_request()
         ^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\sifluegel\Desktop\Chebifier\backend\.venv\Lib\site-packages\flask\app.py", line 902, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)  # type: ignore[no-any-return]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\sifluegel\Desktop\Chebifier\backend\.venv\Lib\site-packages\flask_restful\__init__.py", line 489, in wrapper
    resp = resource(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\sifluegel\Desktop\Chebifier\backend\.venv\Lib\site-packages\flask\views.py", line 110, in view
    return current_app.ensure_sync(self.dispatch_request)(**kwargs)  # type: ignore[no-any-return]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\sifluegel\Desktop\Chebifier\backend\.venv\Lib\site-packages\flask_restful\__init__.py", line 604, in dispatch_request
    resp = meth(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\sifluegel\Desktop\Chebifier\backend\api\chemclass.py", line 121, in post
    all_predicted, intermediate_results = ENSEMBLE.predict_smiles_list(smiles, return_intermediate_results=True)
                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\sifluegel\PycharmProjects\python-chebifier\chebifier\ensemble\base_ensemble.py", line 224, in predict_smiles_list
    ordered_predictions, predicted_classes = self.gather_predictions(smiles_list)
                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\sifluegel\PycharmProjects\python-chebifier\chebifier\ensemble\base_ensemble.py", line 93, in gather_predictions
    model_predictions.append(model.predict_smiles_list(smiles_list))
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\sifluegel\PycharmProjects\python-chebifier\chebifier\_custom_cache.py", line 139, in wrapper
    new_results = func(instance, tuple(missing_smiles))
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\sifluegel\PycharmProjects\python-chebifier\chebifier\prediction_models\nn_predictor.py", line 73, in predict_smiles_list
    d = self.read_smiles(smiles)
        ^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\sifluegel\PycharmProjects\python-chebifier\chebifier\prediction_models\gnn_predictor.py", line 90, in read_smiles
    [property.encoder.encode(v) for v in property_value]
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\sifluegel\PycharmProjects\python-chebai-graph\chebai_graph\preprocessing\property_encoder.py", line 216, in encode
    if token not in self.tokens_dict:
                    ^^^^^^^^^^^^^^^^^
AttributeError: 'OneHotEncoder' object has no attribute 'tokens_dict
```