### PR TITLE
Fix PubChem dataset name

### DIFF
--- a/chebai_graph/preprocessing/datasets/pubchem.py
+++ b/chebai_graph/preprocessing/datasets/pubchem.py
@@ -1,7 +1,7 @@
-from chebai.preprocessing.datasets.pubchem import Pubchem
+from chebai.preprocessing.datasets.pubchem import PubChem
 
 from chebai_graph.preprocessing.datasets.chebi import GraphPropertiesMixIn
 
 
-class PubChemGraphProperties(GraphPropertiesMixIn, Pubchem):
+class PubChemGraphProperties(GraphPropertiesMixIn, PubChem):
     pass

--- a/chebai_graph/preprocessing/datasets/pubchem.py
+++ b/chebai_graph/preprocessing/datasets/pubchem.py
@@ -1,7 +1,7 @@
-from chebai.preprocessing.datasets.pubchem import PubchemChem
+from chebai.preprocessing.datasets.pubchem import Pubchem
 
 from chebai_graph.preprocessing.datasets.chebi import GraphPropertiesMixIn
 
 
-class PubChemGraphProperties(GraphPropertiesMixIn, PubchemChem):
+class PubChemGraphProperties(GraphPropertiesMixIn, Pubchem):
     pass


### PR DESCRIPTION
https://github.com/ChEB-AI/python-chebai/pull/167 has removed the PubchemChem dataset and replaced it with PubChem. This PR adjusts the name accordingly.