### PR TITLE
add compression to property files

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ The list can be found in the `configs/data/chebi50_graph_properties.yml` file.
 python -m chebai fit --trainer=configs/training/default_trainer.yml --trainer.logger=configs/training/csv_logger.yml --model=../python-chebai-graph/configs/model/gnn_res_gated.yml --model.train_metrics=configs/metrics/micro-macro-f1.yml --model.test_metrics=configs/metrics/micro-macro-f1.yml --model.val_metrics=configs/metrics/micro-macro-f1.yml --data=../python-chebai-graph/configs/data/chebi50_graph_properties.yml --data.init_args.batch_size=128 --trainer.accumulate_grad_batches=4 --data.init_args.num_workers=10 --model.pass_loss_kwargs=false --data.init_args.chebi_version=241 --trainer.min_epochs=200 --trainer.max_epochs=200 --model.criterion=configs/loss/bce_weighted.yml
 ```
 
-## Augmented Graphs 
+## Augmented Graphs
 _See thesis related to this work [here](https://www.uni-osnabrueck.de/fileadmin/informatik/Arbeitsgruppen/Hybride_KI/mt_aditya_khedekar.pdf)_.
 
 Graph Neural Networks (GNNs) often fail to explicitly leverage the chemically meaningful substructures present within molecules (i.e. **functional groups (FGs)**).  To make this implicit information explicitly accessible to GNNs, we augment molecular graphs with **artificial nodes** that represent these substructures. The resulting graph are referred to as **augmented graphs**.

--- a/chebai_graph/preprocessing/datasets/chebi.py
+++ b/chebai_graph/preprocessing/datasets/chebi.py
@@ -168,7 +168,12 @@ class DataPropertiesSetter(ChEBIOverX, ABC):
                     assert len(encoded_values) == len(idents) == len(features)
                     torch.save(
                         [
-                            {property.name: torch.cat(feat), "ident": id}
+                            {
+                                property.name: property.encoder.compress(
+                                    torch.cat(feat)
+                                ),
+                                "ident": id,
+                            }
                             for feat, id in zip(encoded_values, idents)
                             if feat is not None
                         ],
@@ -384,6 +389,8 @@ class GraphPropertiesMixIn(DataPropertiesSetter, ABC):
             property_data = torch.load(
                 self.get_property_path(property), weights_only=False
             )
+            for entry in property_data:
+                entry[property.name] = property.encoder.decompress(entry[property.name])
             if len(property_data[0][property.name].shape) > 1:
                 property.encoder.set_encoding_length(
                     property_data[0][property.name].shape[1]
@@ -535,6 +542,8 @@ class GraphPropAsPerNodeType(DataPropertiesSetter, ABC):
             property_data = torch.load(
                 self.get_property_path(property), weights_only=False
             )
+            for entry in property_data:
+                entry[property.name] = property.encoder.decompress(entry[property.name])
             if len(property_data[0][property.name].shape) > 1:
                 property.encoder.set_encoding_length(
                     property_data[0][property.name].shape[1]

--- a/chebai_graph/preprocessing/property_encoder.py
+++ b/chebai_graph/preprocessing/property_encoder.py
@@ -311,19 +311,20 @@ class OneHotEncoder(IndexEncoder):
                 :meth:`compress`.
 
         Returns:
-            One-hot tensor of shape ``(N, n_classes)`` with ``int64`` dtype.
+            One-hot tensor of shape ``(N, n_classes)`` keeping the compact
+            stored dtype (e.g. ``uint8``); it is promoted to float when merged
+            into the node/edge feature matrix at load time.
         """
         if tensor.dim() != 1:
             # already expanded / unexpected shape - leave untouched
             return tensor
         n_classes = self.get_encoding_length()
-        indices = tensor.to(torch.int64)
-        out = torch.zeros((indices.shape[0], n_classes), dtype=torch.int64)
-        non_zero = indices > 0
+        out = torch.zeros((tensor.shape[0], n_classes), dtype=tensor.dtype)
+        non_zero = tensor > 0
         if non_zero.any():
             out[non_zero] = torch.nn.functional.one_hot(
-                indices[non_zero] - 1, num_classes=n_classes
-            )
+                tensor[non_zero].to(torch.int64) - 1, num_classes=n_classes
+            ).to(out.dtype)
         return out
 
 
@@ -365,8 +366,6 @@ class AsIsEncoder(PropertyEncoder):
             return tensor.to(torch.float32)
         return tensor
 
-    # decompress is a no-op: float32 values are used as-is at load time.
-
 
 class BoolEncoder(PropertyEncoder):
     """
@@ -393,7 +392,3 @@ class BoolEncoder(PropertyEncoder):
     def compress(self, tensor: torch.Tensor) -> torch.Tensor:
         """Store the 0/1 values as ``uint8`` instead of ``int64`` (8x smaller)."""
         return tensor.to(torch.uint8)
-
-    def decompress(self, tensor: torch.Tensor) -> torch.Tensor:
-        """Restore the original ``int64`` dtype of the boolean encoding."""
-        return tensor.to(torch.int64)

--- a/chebai_graph/preprocessing/property_encoder.py
+++ b/chebai_graph/preprocessing/property_encoder.py
@@ -46,6 +46,39 @@ class PropertyEncoder(abc.ABC):
         """
         return value
 
+    def compress(self, tensor: torch.Tensor) -> torch.Tensor:
+        """
+        Compress an encoded tensor into a more compact on-disk representation.
+
+        Called just before caching property values to disk. The default
+        implementation is a no-op; subclasses override it to reduce file size
+        (e.g. by downcasting the dtype or storing indices instead of one-hot
+        vectors). Must be losslessly invertible by :meth:`decompress` (except
+        for deliberate float precision reductions).
+
+        Args:
+            tensor: The encoded property tensor for a single molecule.
+
+        Returns:
+            A compact tensor to store on disk.
+        """
+        return tensor
+
+    def decompress(self, tensor: torch.Tensor) -> torch.Tensor:
+        """
+        Reconstruct the full encoded tensor from its compressed on-disk form.
+
+        Inverse of :meth:`compress`, called right after loading cached property
+        values. The default implementation is a no-op.
+
+        Args:
+            tensor: The compressed property tensor as loaded from disk.
+
+        Returns:
+            The reconstructed encoded property tensor.
+        """
+        return tensor
+
     def on_start(self, **kwargs) -> None:
         """Hook called at the start of encoding process."""
         pass
@@ -238,6 +271,61 @@ class OneHotEncoder(IndexEncoder):
             self.tokens_dict[token], num_classes=self.get_encoding_length()
         )
 
+    def compress(self, tensor: torch.Tensor) -> torch.Tensor:
+        """
+        Store one index per node instead of the full one-hot matrix.
+
+        A dense ``(N, n_classes)`` int64 one-hot matrix is reduced to an
+        ``(N,)`` vector of class indices. Index ``0`` is reserved for all-zero
+        rows (produced by :meth:`encode` for unknown tokens); real classes are
+        stored as ``argmax + 1``. The result uses ``uint8`` when it fits, else
+        ``int16``.
+
+        Args:
+            tensor: One-hot tensor of shape ``(N, n_classes)``.
+
+        Returns:
+            Index tensor of shape ``(N,)``.
+        """
+        if tensor.dim() != 2:
+            # already compressed / unexpected shape - leave untouched
+            return tensor
+        has_class = tensor.any(dim=1)
+        indices = torch.where(
+            has_class,
+            tensor.argmax(dim=1) + 1,
+            torch.zeros_like(has_class, dtype=torch.long),
+        )
+        dtype = torch.uint8 if tensor.shape[1] + 1 < 256 else torch.int16
+        return indices.to(dtype)
+
+    def decompress(self, tensor: torch.Tensor) -> torch.Tensor:
+        """
+        Reconstruct the dense one-hot matrix from stored class indices.
+
+        Inverse of :meth:`compress`. Index ``0`` maps back to an all-zero row;
+        index ``i > 0`` maps to a one-hot with class ``i - 1`` set.
+
+        Args:
+            tensor: Index tensor of shape ``(N,)`` as produced by
+                :meth:`compress`.
+
+        Returns:
+            One-hot tensor of shape ``(N, n_classes)`` with ``int64`` dtype.
+        """
+        if tensor.dim() != 1:
+            # already expanded / unexpected shape - leave untouched
+            return tensor
+        n_classes = self.get_encoding_length()
+        indices = tensor.to(torch.int64)
+        out = torch.zeros((indices.shape[0], n_classes), dtype=torch.int64)
+        non_zero = indices > 0
+        if non_zero.any():
+            out[non_zero] = torch.nn.functional.one_hot(
+                indices[non_zero] - 1, num_classes=n_classes
+            )
+        return out
+
 
 class AsIsEncoder(PropertyEncoder):
     """
@@ -271,6 +359,14 @@ class AsIsEncoder(PropertyEncoder):
         # ----- fix: for above warning
         return torch.tensor(token).unsqueeze(0)  # shape: (1, len(token))
 
+    def compress(self, tensor: torch.Tensor) -> torch.Tensor:
+        """Downcast float values to float32 to halve the on-disk size."""
+        if tensor.is_floating_point():
+            return tensor.to(torch.float32)
+        return tensor
+
+    # decompress is a no-op: float32 values are used as-is at load time.
+
 
 class BoolEncoder(PropertyEncoder):
     """
@@ -293,3 +389,11 @@ class BoolEncoder(PropertyEncoder):
             Tensor with 1 if True else 0.
         """
         return torch.tensor([1 if token else 0])
+
+    def compress(self, tensor: torch.Tensor) -> torch.Tensor:
+        """Store the 0/1 values as ``uint8`` instead of ``int64`` (8x smaller)."""
+        return tensor.to(torch.uint8)
+
+    def decompress(self, tensor: torch.Tensor) -> torch.Tensor:
+        """Restore the original ``int64`` dtype of the boolean encoding."""
+        return tensor.to(torch.int64)

--- a/chebai_graph/preprocessing/property_encoder.py
+++ b/chebai_graph/preprocessing/property_encoder.py
@@ -296,8 +296,7 @@ class OneHotEncoder(IndexEncoder):
             tensor.argmax(dim=1) + 1,
             torch.zeros_like(has_class, dtype=torch.long),
         )
-        dtype = torch.uint8 if tensor.shape[1] + 1 < 256 else torch.int16
-        return indices.to(dtype)
+        return indices.to(torch.int16)
 
     def decompress(self, tensor: torch.Tensor) -> torch.Tensor:
         """


### PR DESCRIPTION
Property files take up an absurd amount of disk space. 

For instance, for a ChEBI50 dataset (v244), the `graph_properties\properties` folder has nearly 10GB. `AtomType_one_hot.pt` alone has 6.4GB.

This PR compresses data before saving it to a file (and decompresses when loading). Especially the one-hot encodings don't need to be saved as one-hot tensors. So they are now stored as 1-d and re-converted to one-hot when loading.

File sizes are reduced by a factor of up to 109:

```
DONE  AtomAromaticity_bool.pt: 106.9 MB -> 59.6 MB (1.8x)
DONE  AtomCharge_one_hot.pt: 743.5 MB -> 59.0 MB (12.6x)
DONE  AtomHybridization_one_hot.pt: 427.6 MB -> 61.3 MB (7.0x)
DONE  AtomNumHs_one_hot.pt: 424.4 MB -> 58.7 MB (7.2x)
DONE  AtomType_one_hot.pt: 6376.0 MB -> 58.5 MB (109.0x)
DONE  BondAromaticity_bool.pt: 109.5 MB -> 59.8 MB (1.8x)
DONE  BondInRing_bool.pt: 107.1 MB -> 58.2 MB (1.8x)
DONE  BondType_one_hot.pt: 331.8 MB -> 58.5 MB (5.7x)
DONE  NumAtomBonds_one_hot.pt: 639.1 MB -> 59.6 MB (10.7x)
DONE  RDKit2DNormalized_asis.pt: 360.7 MB -> 203.5 MB (1.8x)
```