### PR TITLE
fix molecule sanitization in reader.py

### DIFF
--- a/chebai_graph/preprocessing/fg_detection/fg_aware_rule_based.py
+++ b/chebai_graph/preprocessing/fg_detection/fg_aware_rule_based.py
@@ -8,7 +8,7 @@ from rdkit import Chem
 from rdkit.Chem import AllChem
 from rdkit.Chem import MolToSmiles as m2s
 
-from chebi_utils.sdf_extractor import _sanitize_molecule
+from chebi_utils.read_molecule import smiles_or_inchi_to_mol
 
 from .fg_constants import ELEMENTS, FLAG_NO_FG
 
@@ -1913,11 +1913,7 @@ def get_structure(mol):
         structure[frag] = {"atom": atom_idx, "is_ring_fg": False}
 
         # Convert fragment SMILES back to mol to match with fused ring atom indices
-        frag_mol = Chem.MolFromSmiles(frag, sanitize=False)
-        try:
-            frag_mol = _sanitize_molecule(frag_mol)
-        except Exception:
-            pass
+        frag_mol = smiles_or_inchi_to_mol(frag)
         frag_rings = frag_mol.GetRingInfo().AtomRings()
         if len(frag_rings) >= 1:
             structure[frag]["is_ring_fg"] = True

--- a/chebai_graph/preprocessing/reader/augmented_reader.py
+++ b/chebai_graph/preprocessing/reader/augmented_reader.py
@@ -4,7 +4,7 @@ from abc import ABC
 
 import torch
 from chebai.preprocessing.reader import DataReader
-from chebi_utils.sdf_extractor import _sanitize_molecule
+from chebi_utils.read_molecule import smiles_or_inchi_to_mol
 from rdkit import Chem
 from torch_geometric.data import Data as GeomData
 
@@ -75,7 +75,7 @@ class _AugmentorReader(DataReader, ABC):
             RuntimeError: If an unexpected error occurs during graph augmentation.
         """
         if isinstance(raw_data, str):
-            mol = self._smiles_to_mol(raw_data)
+            mol = smiles_or_inchi_to_mol(raw_data)
             smiles = raw_data
         else:
             mol = raw_data
@@ -138,29 +138,6 @@ class _AugmentorReader(DataReader, ABC):
             ),
             augmented_molecule,
         )
-
-    def _smiles_to_mol(self, smiles: str) -> Chem.Mol | None:
-        """
-        Converts a SMILES string to an RDKit molecule object. Sanitizes the molecule.
-
-        Args:
-            smiles (str): SMILES string representing the molecule.
-
-        Returns:
-            Chem.Mol | None: RDKit molecule object if successful, else None.
-        """
-        mol = Chem.MolFromSmiles(smiles, sanitize=False)
-        if mol is None:
-            print(f"RDKit failed to parse {smiles} (returned None)")
-            self.f_cnt_for_smiles += 1
-        else:
-            try:
-                mol = _sanitize_molecule(mol)
-            except Exception as e:
-                print(f"RDKit failed at sanitizing {smiles}, Error {e}")
-                self.f_cnt_for_smiles += 1
-                mol = None
-        return mol
 
     def _create_augmented_graph(
         self, mol: Chem.Mol
@@ -315,7 +292,7 @@ class _AugmentorReader(DataReader, ABC):
                 smiles = raw_data
                 if smiles in self.mol_object_buffer:
                     return property.get_property_value(self.mol_object_buffer[smiles])
-                mol = self._smiles_to_mol(smiles)
+                mol = smiles_or_inchi_to_mol(smiles)
             if mol is None:
                 return None
             try:

--- a/chebai_graph/preprocessing/reader/reader.py
+++ b/chebai_graph/preprocessing/reader/reader.py
@@ -60,7 +60,7 @@ class GraphPropertyReader(dr.DataReader):
             self.failed_counter += 1
         else:
             try:
-                _sanitize_molecule(mol)
+                mol = _sanitize_molecule(mol)
             except Exception as e:
                 print(f"Rdkit failed at sanitizing {smiles}, \n Error: {e}")
                 self.failed_counter += 1
@@ -213,7 +213,7 @@ class GraphReader(dr.ChemDataReader):
             print(f"RDKit failed to at parsing {smiles} (returned None)")
         else:
             try:
-                _sanitize_molecule(mol)
+                mol = _sanitize_molecule(mol)
             except Exception as e:
                 print(f"Rdkit failed at sanitizing {smiles}, \n Error: {e}")
         return mol

--- a/chebai_graph/preprocessing/reader/reader.py
+++ b/chebai_graph/preprocessing/reader/reader.py
@@ -166,7 +166,6 @@ class GraphReader(dr.ChemDataReader):
             )
         except ValueError:
             return None
-        assert isinstance(mol, nx.Graph)
         d: dict[int, int] = {}
         de: dict[tuple[int, int], int] = {}
         for node in mol.nodes:

--- a/chebai_graph/preprocessing/reader/reader.py
+++ b/chebai_graph/preprocessing/reader/reader.py
@@ -1,7 +1,7 @@
 import os
 
 import chebai.preprocessing.reader as dr
-from chebi_utils.sdf_extractor import _sanitize_molecule
+from chebi_utils.read_molecule import smiles_or_inchi_to_mol
 import networkx as nx
 import rdkit.Chem as Chem
 import torch
@@ -29,7 +29,7 @@ class GraphPropertyReader(dr.DataReader):
         """
         super().__init__(*args, **kwargs)
         self.failed_counter = 0
-        self.mol_object_buffer: dict[str, Chem.rdchem.Mol | None] = {}
+        self.mol_object_buffer: dict[str, Chem.Mol | None] = {}
 
     @classmethod
     def name(cls) -> str:
@@ -41,7 +41,7 @@ class GraphPropertyReader(dr.DataReader):
         """
         return "graph_properties"
 
-    def _smiles_to_mol(self, smiles: str) -> Chem.rdchem.Mol | None:
+    def _smiles_to_mol(self, smiles: str) -> Chem.Mol | None:
         """
         Load SMILES string into an RDKit molecule object and cache it.
 
@@ -49,21 +49,12 @@ class GraphPropertyReader(dr.DataReader):
             smiles (str): The SMILES string to parse.
 
         Returns:
-            Chem.rdchem.Mol | None: Parsed molecule object or None if parsing failed.
+            Chem.Mol | None: Parsed molecule object or None if parsing failed.
         """
         if smiles in self.mol_object_buffer:
             return self.mol_object_buffer[smiles]
 
-        mol = Chem.MolFromSmiles(smiles, sanitize=False)
-        if mol is None:
-            print(f"RDKit failed to at parsing {smiles} (returned None)")
-            self.failed_counter += 1
-        else:
-            try:
-                mol = _sanitize_molecule(mol)
-            except Exception as e:
-                print(f"Rdkit failed at sanitizing {smiles}, \n Error: {e}")
-                self.failed_counter += 1
+        mol = smiles_or_inchi_to_mol(smiles)
         self.mol_object_buffer[smiles] = mol
         return mol
 
@@ -162,7 +153,9 @@ class GraphReader(dr.ChemDataReader):
         # raw_data is a SMILES string
         try:
             mol = (
-                self._smiles_to_mol(raw_data) if isinstance(raw_data, str) else raw_data
+                smiles_or_inchi_to_mol(raw_data)
+                if isinstance(raw_data, str)
+                else raw_data
             )
         except ValueError:
             return None
@@ -195,27 +188,6 @@ class GraphReader(dr.ChemDataReader):
         nx.set_edge_attributes(mol, de, "edge_attr")
         data = from_networkx(mol)
         return data
-
-    def _smiles_to_mol(self, smiles: str) -> Chem.rdchem.Mol | None:
-        """
-        Load SMILES string into an RDKit molecule object.
-
-        Args:
-            smiles (str): The SMILES string to parse.
-
-        Returns:
-            Chem.rdchem.Mol | None: Parsed molecule object or None if parsing failed.
-        """
-
-        mol = Chem.MolFromSmiles(smiles, sanitize=False)
-        if mol is None:
-            print(f"RDKit failed to at parsing {smiles} (returned None)")
-        else:
-            try:
-                mol = _sanitize_molecule(mol)
-            except Exception as e:
-                print(f"Rdkit failed at sanitizing {smiles}, \n Error: {e}")
-        return mol
 
     def collate(self, list_of_tuples: list) -> any:
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ authors = [
 ]
 dependencies = [
     "chebai",
+    "chebi_utils>=0.4",
     "descriptastorus",
     # below packages need to manually installed as mentioned in readme
     # torch-geometric


### PR DESCRIPTION
The `_sanitize_molecule` function gets called, but the result is not used (#40 ). This leads to missing values for some of the properties (AtomHybridization gets set to unspecified). 

This does not affect model training because the training dataset does not use SMILES string, but passes molecule objects (which have been created from sanitized molfiles). 

To avoid future discrepancies between training and inference, I moved the SMILES to mol conversion to chebi_utils. This gives us the chance to update the chebai and chebifier repositories as well which both have their own SMILES-processing functionality.

## Todo 
- [x] release new chebi_utils version - https://github.com/ChEB-AI/python-chebi-utils/releases/tag/v0.4
- [x] set pyproject.toml to new version
- [x] update chebai predictor - https://github.com/ChEB-AI/python-chebai/pull/179
- [x] update chebifier CLI - https://github.com/ChEB-AI/python-chebifier/pull/32/changes/32e14a154ae8306673b08ff81a129f414f2d3061